### PR TITLE
Update version to 1.0.2 and adjust dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.4",
     "friendsofphp/php-cs-fixer": "^3.0",
-    "symfony/console": "^5.0|^6.0"
+    "symfony/console": "^4.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0"

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -10,7 +10,7 @@ class Application extends BaseApplication
 {
     public function __construct()
     {
-        parent::__construct('Yii2 Fixer By zhikariz', '1.0.1');
+        parent::__construct('Yii2 Fixer By zhikariz', '1.0.2');
 
         $this->add(new FixCommand());
         $this->add(new VersionCommand());

--- a/src/Console/Commands/FixCommand.php
+++ b/src/Console/Commands/FixCommand.php
@@ -24,7 +24,7 @@ class FixCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
-        $configFile = $input->getOption('config') ?: __DIR__ . '/../../../fixer.json';
+        $configFile = $input->getOption('config') ?: __DIR__ . '/../../../fixer.php';
 
         $output->writeln('Fixing code style...');
 

--- a/src/Console/Commands/VersionCommand.php
+++ b/src/Console/Commands/VersionCommand.php
@@ -18,10 +18,10 @@ class VersionCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln('Yii2 Fixer By zhikariz 1.0.1');
+        $output->writeln('Yii2 Fixer By zhikariz 1.0.2');
         $output->writeln('PHP version: ' . PHP_VERSION);
         $output->writeln('PHP-CS-Fixer version: ' . \PhpCsFixer\Console\Application::VERSION);
 
-        return Command::SUCCESS;
+        return 0;
     }
 }


### PR DESCRIPTION
Bump application version to 1.0.2 in Application and VersionCommand. Change default config file in FixCommand from fixer.json to fixer.php. Update composer.json to require symfony/console ^4.4 instead of ^5.0|^6.0. Return 0 explicitly in VersionCommand execute method.