### PR TITLE
Update to PHP 8.1 and Symfony Console 6, improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Install as a development dependency via Composer:
 composer require --dev zhikariz/yii2-fixer
 ```
 
+**Note**: This package requires PHP 8.1+. If your project uses an older PHP version, you can still install it by setting the `PHP_CS_FIXER_IGNORE_ENV` environment variable:
+
+```bash
+PHP_CS_FIXER_IGNORE_ENV=1 composer require --dev zhikariz/yii2-fixer
+```
+
+However, the tool will only work on PHP 8.1+ systems.
+
 Or clone the repository and run:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     }
   ],
   "require": {
-    "php": "^7.4",
+    "php": "^8.1",
     "friendsofphp/php-cs-fixer": "^3.0",
-    "symfony/console": "^4.4"
+    "symfony/console": "^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0"

--- a/src/Console/Commands/VersionCommand.php
+++ b/src/Console/Commands/VersionCommand.php
@@ -22,6 +22,6 @@ class VersionCommand extends Command
         $output->writeln('PHP version: ' . PHP_VERSION);
         $output->writeln('PHP-CS-Fixer version: ' . \PhpCsFixer\Console\Application::VERSION);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Bump minimum PHP version to 8.1 and require symfony/console ^6.0 in composer.json. Update README with PHP 8.1+ requirement and installation workaround for older PHP versions. Refactor VersionCommand to use Command::SUCCESS for return value.