### PR TITLE
Add DocBlockCommand and update version to 1.1.0

### DIFF
--- a/bin/yii2-fixer
+++ b/bin/yii2-fixer
@@ -1,5 +1,9 @@
 #!/usr/bin/env php
 <?php
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
 
 // Include autoload - check multiple possible locations
 $autoloadPaths = [

--- a/fixer.php
+++ b/fixer.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
 $config = new PhpCsFixer\Config();
 
 $config->setRules([

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,17 +1,27 @@
 <?php
 
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
+
 namespace zhikariz\yii2\fixer\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
+use zhikariz\yii2\fixer\Console\Commands\DocBlockCommand;
 use zhikariz\yii2\fixer\Console\Commands\FixCommand;
 use zhikariz\yii2\fixer\Console\Commands\VersionCommand;
 
 class Application extends BaseApplication
 {
+    /**
+     * @return mixed
+     */
     public function __construct()
     {
-        parent::__construct('Yii2 Fixer By zhikariz', '1.0.2');
+        parent::__construct('Yii2 Fixer By zhikariz', '1.1.0');
 
+        $this->add(new DocBlockCommand());
         $this->add(new FixCommand());
         $this->add(new VersionCommand());
     }

--- a/src/Console/Commands/DocBlockCommand.php
+++ b/src/Console/Commands/DocBlockCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
+
+
+namespace zhikariz\yii2\fixer\Console\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+
+class DocBlockCommand extends Command
+{
+    protected static $defaultName = 'docblock';
+
+    /**
+     * @return mixed
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Generate docblocks for functions and variables in PHP files')
+            ->addArgument('path', InputArgument::OPTIONAL, 'The path to scan', '.');
+    }
+
+    /**
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $path = $input->getArgument('path');
+
+        $output->writeln('Generating docblocks...');
+
+        $finder = Finder::create()
+            ->files()
+            ->name('*.php')
+            ->ignoreDotFiles(true)
+            ->ignoreVCS(true)
+            ->notPath('vendor')
+            ->in($path);
+
+        $filesProcessed = 0;
+        $docblocksAdded = 0;
+
+        foreach ($finder as $file) {
+            $content = $file->getContents();
+            $lines = explode("\n", $content);
+            $insertions = [];
+
+            for ($i = 0; $i < count($lines); $i++) {
+                $line = $lines[$i];
+
+                // Check for function declaration
+                if (preg_match('/^\s*(public|private|protected)?\s*function\s+(\w+)\s*\(([^)]*)\)(?:\s*:\s*([^;\s{]+))?/', $line, $matches)) {
+                    // Check if previous line is not a docblock
+                    $prevLine = $i > 0 ? trim($lines[$i - 1]) : '';
+                    if (!preg_match('/^\s*\*\//', $prevLine) && !preg_match('/^\s*\/\*\*/', $prevLine)) {
+                        $functionName = $matches[2];
+                        $params = $matches[3] ?? '';
+                        $returnType = $matches[4] ?? 'mixed';
+
+                        $docblock = ['    /**'];
+
+                        // Parse parameters
+                        if (!empty($params)) {
+                            $paramList = explode(',', $params);
+                            foreach ($paramList as $param) {
+                                $param = trim($param);
+                                if (preg_match('/(\w+)\s+\$(\w+)/', $param, $paramMatches)) {
+                                    $paramType = $paramMatches[1];
+                                    $paramName = $paramMatches[2];
+                                    $docblock[] = '     * @param ' . $paramType . ' $' . $paramName;
+                                }
+                            }
+                        }
+
+                        $docblock[] = '     * @return ' . $returnType;
+                        $docblock[] = '     */';
+
+                        // Add insertion before this line
+                        $insertions[] = [
+                            'line' => $i,
+                            'content' => $docblock
+                        ];
+                        $docblocksAdded++;
+                    }
+                }
+
+                // Check for property declaration (simple case: visibility $var)
+                if (preg_match('/^\s*(public|private|protected)\s+\$\w+/', $line)) {
+                    // Check if previous line is not a docblock
+                    $prevLine = $i > 0 ? trim($lines[$i - 1]) : '';
+                    if (!preg_match('/^\s*\*\//', $prevLine) && !preg_match('/^\s*\/\*\*/', $prevLine)) {
+                        // Add insertion before this line
+                        $insertions[] = [
+                            'line' => $i,
+                            'content' => [
+                                '    /**',
+                                '     * @var mixed',
+                                '     */'
+                            ]
+                        ];
+                        $docblocksAdded++;
+                    }
+                }
+            }
+
+            // Apply insertions from bottom to top
+            $insertions = array_reverse($insertions);
+            foreach ($insertions as $insertion) {
+                array_splice($lines, $insertion['line'], 0, $insertion['content']);
+            }
+
+            $newContent = implode("\n", $lines);
+            if ($newContent !== $content) {
+                file_put_contents($file->getRealPath(), $newContent);
+                $filesProcessed++;
+            }
+        }
+
+        $output->writeln("Processed $filesProcessed files, added $docblocksAdded docblocks.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/Commands/FixCommand.php
+++ b/src/Console/Commands/FixCommand.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
+
+
 namespace zhikariz\yii2\fixer\Console\Commands;
 
 use Symfony\Component\Console\Command\Command;
@@ -7,12 +13,14 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Finder\Finder;
 
 class FixCommand extends Command
 {
     protected static $defaultName = 'fix';
 
+    /**
+     * @return mixed
+     */
     protected function configure()
     {
         $this
@@ -21,6 +29,11 @@ class FixCommand extends Command
             ->addOption('config', 'c', InputOption::VALUE_OPTIONAL, 'The path to a config file');
     }
 
+    /**
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $path = $input->getArgument('path');
@@ -34,6 +47,13 @@ class FixCommand extends Command
 
         if ($returnCode === 0) {
             $output->writeln('Code style fixed successfully.');
+
+            // Remove PHP-CS-Fixer cache file
+            $cacheFile = '.php-cs-fixer.cache';
+            if (file_exists($cacheFile)) {
+                unlink($cacheFile);
+                $output->writeln('Removed .php-cs-fixer.cache file.');
+            }
         } else {
             $output->writeln('Error fixing code style.');
             foreach ($outputLines as $line) {
@@ -42,28 +62,5 @@ class FixCommand extends Command
         }
 
         return $returnCode === 0 ? Command::SUCCESS : Command::FAILURE;
-    }
-
-    private function getRules(): array
-    {
-        return [
-            '@PSR2' => true,
-            'array_syntax' => ['syntax' => 'short'],
-            'indentation_type' => true,
-            'no_unused_imports' => true,
-            'single_quote' => true,
-            'braces' => ['allow_single_line_closure' => true],
-            'class_attributes_separation' => ['elements' => ['const' => 'one', 'method' => 'one', 'property' => 'one']],
-            'no_blank_lines_after_class_opening' => true,
-            'no_blank_lines_after_phpdoc' => true,
-            'phpdoc_align' => ['align' => 'vertical'],
-            'phpdoc_indent' => true,
-            'phpdoc_no_access' => true,
-            'phpdoc_no_package' => true,
-            'phpdoc_scalar' => true,
-            'phpdoc_trim' => true,
-            'phpdoc_types' => true,
-            'phpdoc_var_without_name' => true,
-        ];
     }
 }

--- a/src/Console/Commands/VersionCommand.php
+++ b/src/Console/Commands/VersionCommand.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
+
+
 namespace zhikariz\yii2\fixer\Console\Commands;
 
 use Symfony\Component\Console\Command\Command;
@@ -10,15 +16,23 @@ class VersionCommand extends Command
 {
     protected static $defaultName = 'version';
 
+    /**
+     * @return mixed
+     */
     protected function configure()
     {
         $this
             ->setDescription('Show version information');
     }
 
+    /**
+     * @param  InputInterface  $input
+     * @param  OutputInterface $output
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln('Yii2 Fixer By zhikariz 1.0.2');
+        $output->writeln('Yii2 Fixer By zhikariz 1.1.0');
         $output->writeln('PHP version: ' . PHP_VERSION);
         $output->writeln('PHP-CS-Fixer version: ' . \PhpCsFixer\Console\Application::VERSION);
 

--- a/tests/FixCommandTest.php
+++ b/tests/FixCommandTest.php
@@ -1,14 +1,22 @@
 <?php
 
+/**
+ * @author Helmi Adi Prasetyo <helmi.prasetyo12@gmail.com>
+ * @copyright Copyright (c) Helmi Adi Prasetyo
+ */
+
+
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Tester\CommandTester;
 use zhikariz\yii2\fixer\Console\Commands\FixCommand;
 
 class FixCommandTest extends TestCase
 {
+    /**
+     * @return mixed
+     */
     public function testCommandExists()
     {
         $application = new Application();
@@ -18,6 +26,9 @@ class FixCommandTest extends TestCase
         $this->assertInstanceOf(FixCommand::class, $command);
     }
 
+    /**
+     * @return mixed
+     */
     public function testCommandDescription()
     {
         $command = new FixCommand();


### PR DESCRIPTION
Introduced a new DocBlockCommand to generate docblocks for PHP functions and variables. Updated the application and version command to reflect version 1.1.0. Added author and copyright headers to several files, improved FixCommand to remove the PHP-CS-Fixer cache file after fixing, and enhanced test coverage with docblocks.